### PR TITLE
Make escape parameter explicit for PHP 8.4

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -11,6 +11,8 @@ class CSVResponse extends Response
 
     public const COMMA = ',';
     public const SEMICOLON = ';';
+    public const DOUBLEQUOTE = '"';
+    public const DOUBLESLASH = '\\';
 
     public function __construct(array $data, ?string $fileName = null, ?string $separator = self::SEMICOLON)
     {
@@ -35,7 +37,7 @@ class CSVResponse extends Response
     {
         $fp = fopen('php://temp', 'w');
         foreach ($this->prepareData($data) as $fields) {
-            fputcsv($fp, $fields, $this->separator);
+            fputcsv($fp, $fields, $this->separator, self::DOUBLEQUOTE, self::DOUBLESLASH);
         }
 
         rewind($fp);


### PR DESCRIPTION
PHP 8.4 [requires that fputcsv have an explicit `escape` argument](https://www.php.net/manual/en/function.fputcsv.php).

Not sure if I need to add 8.4 to the testing matrix, but this satisfies the deprecation warning.

Also, not sure if double slash is actually the correct character to use, or if it should just be an empty string.