### PR TITLE
Fix DateTimeImmutable not being formatted

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -62,7 +62,7 @@ class CSVResponse extends Response
 
             $line = [];
             foreach ($row as $key => $value) {
-                if (is_object($value) && get_class($value) == 'DateTime') {
+                if ($value instanceof \DateTimeInterface) {
                     $value = $value->format('Y-m-d H:i:s');
                 }
                 $line[] = $value;

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -59,4 +59,16 @@ class CSVResponseTest extends TestCase
             $response->getContent()
         );
     }
+
+    public function testDateTimeImmutable(): void
+    {
+        $now = new \DateTimeImmutable();
+        $response = new CSVResponse([
+            ['datetime' => $now],
+        ]);
+        $this->assertStringContainsString(
+            $now->format('Y-m-d H:i:s'),
+            $response->getContent()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Use `instanceof \DateTimeInterface` instead of `get_class() == 'DateTime'` so that `DateTimeImmutable` (and any custom `DateTimeInterface` implementation) is properly formatted
- Add test for `DateTimeImmutable` formatting

Closes #9

## Test plan

- [x] Existing `testDateTime` still passes
- [x] New `testDateTimeImmutable` test passes