### PR TITLE
Add configurable DateTime format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /phpunit-9.5.4.phar
 /.phpunit.result.cache
 /.php-cs-fixer.cache
+CLAUDE.md

--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -8,6 +8,7 @@ class CSVResponse extends Response
 {
     private string $fileName = 'CSVExport.csv';
     private ?string $separator = null;
+    private string $dateFormat = 'Y-m-d H:i:s';
 
     public const COMMA = ',';
     public const SEMICOLON = ';';
@@ -18,11 +19,13 @@ class CSVResponse extends Response
         array $data,
         ?string $fileName = null,
         ?string $separator = self::SEMICOLON,
-        bool $addBom = false
+        bool $addBom = false,
+        string $dateFormat = 'Y-m-d H:i:s'
     ) {
         parent::__construct();
 
         $this->separator = $separator;
+        $this->dateFormat = $dateFormat;
         if ($fileName) {
             $this->setFileName($fileName);
         }
@@ -71,7 +74,7 @@ class CSVResponse extends Response
             $line = [];
             foreach ($row as $key => $value) {
                 if ($value instanceof \DateTimeInterface) {
-                    $value = $value->format('Y-m-d H:i:s');
+                    $value = $value->format($this->dateFormat);
                 } elseif (is_bool($value)) {
                     $value = $value ? 'true' : 'false';
                 } elseif (is_null($value)) {

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -112,6 +112,34 @@ class CSVResponseTest extends TestCase
         );
     }
 
+    public function testCustomDateFormat(): void
+    {
+        $now = new \DateTime('2025-06-15 14:30:00');
+        $response = new CSVResponse(
+            [['datetime' => $now]],
+            null,
+            CSVResponse::SEMICOLON,
+            false,
+            'd/m/Y'
+        );
+        $this->assertSame(
+            "datetime\n15/06/2025\n",
+            $response->getContent()
+        );
+    }
+
+    public function testDefaultDateFormatUnchanged(): void
+    {
+        $now = new \DateTime('2025-06-15 14:30:00');
+        $response = new CSVResponse([
+            ['datetime' => $now],
+        ]);
+        $this->assertStringContainsString(
+            '2025-06-15 14:30:00',
+            $response->getContent()
+        );
+    }
+
     public function testNestedArrayThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
## Summary
- Adds a `$dateFormat` constructor parameter to `CSVResponse` (default `'Y-m-d H:i:s'`)
- Allows users to customize how `DateTimeInterface` values are formatted in CSV output (e.g. `d/m/Y`, ISO 8601)
- Fully backward-compatible, no breaking changes

Closes #14

## Test plan
- [x] `testCustomDateFormat` — verifies custom format `d/m/Y` is applied
- [x] `testDefaultDateFormatUnchanged` — verifies default format still works
- [x] All existing tests pass
- [x] CS check and PHPStan pass