### PR TITLE
Add option to disable header row

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -20,7 +20,8 @@ class CSVResponse extends Response
         ?string $fileName = null,
         ?string $separator = self::SEMICOLON,
         bool $addBom = false,
-        string $dateFormat = 'Y-m-d H:i:s'
+        string $dateFormat = 'Y-m-d H:i:s',
+        bool $includeHeaders = true
     ) {
         parent::__construct();
 
@@ -30,7 +31,7 @@ class CSVResponse extends Response
             $this->setFileName($fileName);
         }
 
-        $content = $this->initContent($data);
+        $content = $this->initContent($data, $includeHeaders);
         if ($addBom) {
             $content = "\xEF\xBB\xBF" . $content;
         }
@@ -44,10 +45,10 @@ class CSVResponse extends Response
         $this->fileName = $fileName;
     }
 
-    private function initContent(array $data): string
+    private function initContent(array $data, bool $includeHeaders = true): string
     {
         $fp = fopen('php://temp', 'w');
-        foreach ($this->prepareData($data) as $fields) {
+        foreach ($this->prepareData($data, $includeHeaders) as $fields) {
             fputcsv($fp, $fields, $this->separator, self::DOUBLEQUOTE, self::DOUBLESLASH);
         }
 
@@ -58,12 +59,12 @@ class CSVResponse extends Response
         return $content;
     }
 
-    private function prepareData(array $data): array
+    private function prepareData(array $data, bool $includeHeaders = true): array
     {
         $i = 0;
         $output = [];
         foreach ($data as $row) {
-            if ($i === 0) {
+            if ($i === 0 && $includeHeaders) {
                 $head = [];
                 foreach ($row as $key => $value) {
                     $head[] = $key;

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -140,6 +140,31 @@ class CSVResponseTest extends TestCase
         );
     }
 
+    public function testHeadersIncludedByDefault(): void
+    {
+        $response = new CSVResponse($this->getData());
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $response->getContent()
+        );
+    }
+
+    public function testHeadersDisabled(): void
+    {
+        $response = new CSVResponse(
+            $this->getData(),
+            null,
+            CSVResponse::SEMICOLON,
+            false,
+            'Y-m-d H:i:s',
+            false
+        );
+        $this->assertSame(
+            "Marcel;TOTO\nMaurice;TATA\n",
+            $response->getContent()
+        );
+    }
+
     public function testNestedArrayThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
## Summary
- Add an optional `$includeHeaders` parameter (default `true`) to the constructor, allowing CSV output without the header row
- Closes #13

## Test plan
- [x] `testHeadersIncludedByDefault` — verifies default behavior unchanged
- [x] `testHeadersDisabled` — verifies headers are omitted when `includeHeaders` is `false`
- [x] All existing tests pass
- [x] CS-check and PHPStan pass