### PR TITLE
Support iterable data instead of array only

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -16,7 +16,7 @@ class CSVResponse extends Response
     public const DOUBLESLASH = '\\';
 
     public function __construct(
-        array $data,
+        iterable $data,
         ?string $fileName = null,
         ?string $separator = self::SEMICOLON,
         bool $addBom = false,
@@ -45,7 +45,7 @@ class CSVResponse extends Response
         $this->fileName = $fileName;
     }
 
-    private function initContent(array $data, bool $includeHeaders = true): string
+    private function initContent(iterable $data, bool $includeHeaders = true): string
     {
         $fp = fopen('php://temp', 'w');
         foreach ($this->prepareData($data, $includeHeaders) as $fields) {
@@ -59,7 +59,7 @@ class CSVResponse extends Response
         return $content;
     }
 
-    private function prepareData(array $data, bool $includeHeaders = true): array
+    private function prepareData(iterable $data, bool $includeHeaders = true): array
     {
         $i = 0;
         $output = [];

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -165,6 +165,34 @@ class CSVResponseTest extends TestCase
         );
     }
 
+    public function testIterableWithGenerator(): void
+    {
+        $generator = function () {
+            yield ['firstName' => 'Marcel', 'lastName' => 'TOTO'];
+            yield ['firstName' => 'Maurice', 'lastName' => 'TATA'];
+        };
+
+        $response = new CSVResponse($generator());
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $response->getContent()
+        );
+    }
+
+    public function testIterableWithArrayIterator(): void
+    {
+        $iterator = new \ArrayIterator([
+            ['firstName' => 'Marcel', 'lastName' => 'TOTO'],
+            ['firstName' => 'Maurice', 'lastName' => 'TATA'],
+        ]);
+
+        $response = new CSVResponse($iterator);
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $response->getContent()
+        );
+    }
+
     public function testNestedArrayThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

- Change `$data` type hint from `array` to `iterable` in constructor, `initContent()` and `prepareData()`
- Allows passing generators, `ArrayIterator`, Doctrine collections, or any `Traversable` without breaking existing code
- Add tests for `Generator` and `ArrayIterator` inputs

Closes #11

## Test plan

- [x] Existing tests pass (arrays still work as `iterable`)
- [x] New test: generator input produces correct CSV
- [x] New test: `ArrayIterator` input produces correct CSV
- [x] PHPStan passes at level 5