### PR TITLE
Security: Sanitize CSV values to prevent formula injection

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -15,18 +15,24 @@ class CSVResponse extends Response
     public const DOUBLEQUOTE = '"';
     public const DOUBLESLASH = '\\';
 
+    private bool $sanitizeFormulas = true;
+
+    private const FORMULA_PREFIXES = ['=', '+', '-', '@', "\t", "\r", "\n"];
+
     public function __construct(
         iterable $data,
         ?string $fileName = null,
         ?string $separator = self::SEMICOLON,
         bool $addBom = false,
         string $dateFormat = 'Y-m-d H:i:s',
-        bool $includeHeaders = true
+        bool $includeHeaders = true,
+        bool $sanitizeFormulas = true
     ) {
         parent::__construct();
 
         $this->separator = $separator;
         $this->dateFormat = $dateFormat;
+        $this->sanitizeFormulas = $sanitizeFormulas;
         if ($fileName) {
             $this->setFileName($fileName);
         }
@@ -85,6 +91,11 @@ class CSVResponse extends Response
                         sprintf('Nested arrays are not supported in CSV data (column "%s").', $key)
                     );
                 }
+
+                if ($this->sanitizeFormulas && is_string($value) && isset($value[0]) && in_array($value[0], self::FORMULA_PREFIXES, true)) {
+                    $value = "'" . $value;
+                }
+
                 $line[] = $value;
             }
             $output[] = $line;

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -193,6 +193,61 @@ class CSVResponseTest extends TestCase
         );
     }
 
+    public function testFormulaInjectionSanitized(): void
+    {
+        $data = [
+            ['name' => '=CMD|"/C calc"!A0', 'email' => 'test@test.com'],
+            ['name' => '+SUM(A1:A2)', 'email' => '-data'],
+            ['name' => '@import', 'email' => "\tmalicious"],
+        ];
+
+        $response = new CSVResponse($data);
+        $content = $response->getContent();
+
+        $this->assertStringContainsString("'=CMD", $content);
+        $this->assertStringContainsString("'+SUM", $content);
+        $this->assertStringContainsString("'-data", $content);
+        $this->assertStringContainsString("'@import", $content);
+        $this->assertStringNotContainsString(";=CMD", $content);
+        $this->assertStringNotContainsString(";+SUM", $content);
+        $this->assertStringNotContainsString(";@import", $content);
+    }
+
+    public function testFormulaInjectionSanitizationDisabled(): void
+    {
+        $data = [
+            ['name' => '=SUM(A1:A2)'],
+        ];
+
+        $response = new CSVResponse(
+            $data,
+            null,
+            CSVResponse::SEMICOLON,
+            false,
+            'Y-m-d H:i:s',
+            true,
+            false
+        );
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('=SUM(A1:A2)', $content);
+        $this->assertStringNotContainsString("'=SUM", $content);
+    }
+
+    public function testSafeValuesNotPrefixed(): void
+    {
+        $data = [
+            ['name' => 'Marcel', 'amount' => '100'],
+        ];
+
+        $response = new CSVResponse($data);
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('Marcel', $content);
+        $this->assertStringNotContainsString("'Marcel", $content);
+        $this->assertStringNotContainsString("'100", $content);
+    }
+
     public function testNestedArrayThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

- Prefix dangerous cell values starting with `=`, `+`, `-`, `@`, `\t`, `\r`, `\n` with a single quote (`'`) to prevent spreadsheet formula injection when CSV files are opened in Excel or LibreOffice
- Protection is enabled by default and can be disabled via the `sanitizeFormulas` constructor option (7th parameter)
- Adds 3 tests covering sanitization, opt-out, and safe value passthrough

Closes #23

## Test plan

- [x] All 17 tests pass
- [x] PHPStan: no errors
- [x] php-cs-fixer: no issues