### PR TITLE
Add StreamedCSVResponse for large exports

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -4,23 +4,15 @@ namespace Ilbee\CSVResponse;
 
 use Symfony\Component\HttpFoundation\Response;
 
-class CSVResponse extends Response
+class CSVResponse extends Response implements CSVResponseInterface
 {
-    private string $fileName = 'CSVExport.csv';
-    private ?string $separator = null;
-    private string $dateFormat = 'Y-m-d H:i:s';
+    use CSVResponseTrait;
 
-    public const COMMA = ',';
-    public const SEMICOLON = ';';
-    public const DOUBLEQUOTE = '"';
-    public const DOUBLESLASH = '\\';
-
-    private bool $sanitizeFormulas = true;
-
-    private const FORMULA_PREFIXES = ['=', '+', '-', '@', "\t", "\r", "\n"];
-
+    /**
+     * @param iterable|callable $data
+     */
     public function __construct(
-        iterable $data,
+        $data,
         ?string $fileName = null,
         ?string $separator = self::SEMICOLON,
         bool $addBom = false,
@@ -30,32 +22,42 @@ class CSVResponse extends Response
     ) {
         parent::__construct();
 
-        $this->separator = $separator;
-        $this->dateFormat = $dateFormat;
-        $this->sanitizeFormulas = $sanitizeFormulas;
-        if ($fileName) {
-            $this->setFileName($fileName);
-        }
+        $this->initCSVProperties($fileName, $separator, $dateFormat, $sanitizeFormulas);
 
-        $content = $this->initContent($data, $includeHeaders);
+        $content = $this->initContent($this->resolveData($data), $includeHeaders);
         if ($addBom) {
             $content = "\xEF\xBB\xBF" . $content;
         }
         $this->setContent($content);
         $this->headers->set('Content-Type', 'text/csv');
-        $this->headers->set('Content-Disposition', sprintf('attachment; filename="%s"', $this->fileName));
-    }
-
-    private function setFileName(string $fileName): void
-    {
-        $this->fileName = $fileName;
+        $this->headers->set(
+            'Content-Disposition',
+            sprintf('attachment; filename="%s"', $this->fileName)
+        );
     }
 
     private function initContent(iterable $data, bool $includeHeaders = true): string
     {
         $fp = fopen('php://temp', 'w');
-        foreach ($this->prepareData($data, $includeHeaders) as $fields) {
-            fputcsv($fp, $fields, $this->separator, self::DOUBLEQUOTE, self::DOUBLESLASH);
+        $i = 0;
+        foreach ($data as $row) {
+            if ($i === 0 && $includeHeaders) {
+                fputcsv(
+                    $fp,
+                    $this->extractHeaders($row),
+                    $this->separator,
+                    self::DOUBLEQUOTE,
+                    self::DOUBLESLASH
+                );
+            }
+            fputcsv(
+                $fp,
+                $this->convertRow($row),
+                $this->separator,
+                self::DOUBLEQUOTE,
+                self::DOUBLESLASH
+            );
+            $i++;
         }
 
         rewind($fp);
@@ -63,46 +65,5 @@ class CSVResponse extends Response
         fclose($fp);
 
         return $content;
-    }
-
-    private function prepareData(iterable $data, bool $includeHeaders = true): array
-    {
-        $i = 0;
-        $output = [];
-        foreach ($data as $row) {
-            if ($i === 0 && $includeHeaders) {
-                $head = [];
-                foreach ($row as $key => $value) {
-                    $head[] = $key;
-                }
-                $output[] = $head;
-            }
-
-            $line = [];
-            foreach ($row as $key => $value) {
-                if ($value instanceof \DateTimeInterface) {
-                    $value = $value->format($this->dateFormat);
-                } elseif (is_bool($value)) {
-                    $value = $value ? 'true' : 'false';
-                } elseif (is_null($value)) {
-                    $value = '';
-                } elseif (is_array($value)) {
-                    throw new \InvalidArgumentException(
-                        sprintf('Nested arrays are not supported in CSV data (column "%s").', $key)
-                    );
-                }
-
-                if ($this->sanitizeFormulas && is_string($value) && isset($value[0]) && in_array($value[0], self::FORMULA_PREFIXES, true)) {
-                    $value = "'" . $value;
-                }
-
-                $line[] = $value;
-            }
-            $output[] = $line;
-
-            $i++;
-        }
-
-        return $output;
     }
 }

--- a/src/CSVResponseInterface.php
+++ b/src/CSVResponseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ilbee\CSVResponse;
+
+interface CSVResponseInterface
+{
+    public const COMMA = ',';
+    public const SEMICOLON = ';';
+    public const DOUBLEQUOTE = '"';
+    public const DOUBLESLASH = '\\';
+}

--- a/src/CSVResponseTrait.php
+++ b/src/CSVResponseTrait.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Ilbee\CSVResponse;
+
+trait CSVResponseTrait
+{
+    /** @var string */
+    private $fileName = 'CSVExport.csv';
+
+    /** @var string|null */
+    private $separator = null;
+
+    /** @var string */
+    private $dateFormat = 'Y-m-d H:i:s';
+
+    /** @var bool */
+    private $sanitizeFormulas = true;
+
+    /** @var array<string> */
+    private static $formulaPrefixes = ['=', '+', '-', '@', "\t", "\r", "\n"];
+
+    /**
+     * @param iterable|callable $data
+     * @return iterable
+     */
+    private function resolveData($data): iterable
+    {
+        if (is_callable($data)) {
+            $data = $data();
+            if (!is_iterable($data)) {
+                throw new \InvalidArgumentException(
+                    'The callable must return an iterable.'
+                );
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @return mixed
+     */
+    private function convertValue(string $key, $value)
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format($this->dateFormat);
+        } elseif (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        } elseif (is_null($value)) {
+            return '';
+        } elseif (is_array($value)) {
+            throw new \InvalidArgumentException(
+                sprintf('Nested arrays are not supported in CSV data (column "%s").', $key)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    private function sanitizeValue($value)
+    {
+        if ($this->sanitizeFormulas && is_string($value) && isset($value[0]) && in_array($value[0], self::$formulaPrefixes, true)) {
+            return "'" . $value;
+        }
+
+        return $value;
+    }
+
+    private function initCSVProperties(
+        ?string $fileName,
+        ?string $separator,
+        string $dateFormat,
+        bool $sanitizeFormulas
+    ): void {
+        $this->separator = $separator;
+        $this->dateFormat = $dateFormat;
+        $this->sanitizeFormulas = $sanitizeFormulas;
+        if ($fileName) {
+            $this->fileName = $fileName;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<mixed>
+     */
+    private function convertRow(array $row): array
+    {
+        $line = [];
+        foreach ($row as $key => $value) {
+            $value = $this->convertValue($key, $value);
+            $line[] = $this->sanitizeValue($value);
+        }
+
+        return $line;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string>
+     */
+    private function extractHeaders(array $row): array
+    {
+        return array_keys($row);
+    }
+}

--- a/src/StreamedCSVResponse.php
+++ b/src/StreamedCSVResponse.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Ilbee\CSVResponse;
+
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class StreamedCSVResponse extends StreamedResponse implements CSVResponseInterface
+{
+    use CSVResponseTrait;
+
+    /**
+     * @param iterable|callable $data
+     */
+    public function __construct(
+        $data,
+        ?string $fileName = null,
+        ?string $separator = self::SEMICOLON,
+        bool $addBom = false,
+        string $dateFormat = 'Y-m-d H:i:s',
+        bool $includeHeaders = true,
+        bool $sanitizeFormulas = true
+    ) {
+        $this->initCSVProperties($fileName, $separator, $dateFormat, $sanitizeFormulas);
+
+        $callback = function () use ($data, $addBom, $includeHeaders) {
+            $fp = fopen('php://output', 'w');
+
+            if ($addBom) {
+                fwrite($fp, "\xEF\xBB\xBF");
+            }
+
+            $i = 0;
+            foreach ($this->resolveData($data) as $row) {
+                if ($i === 0 && $includeHeaders) {
+                    fputcsv(
+                        $fp,
+                        $this->extractHeaders($row),
+                        $this->separator,
+                        self::DOUBLEQUOTE,
+                        self::DOUBLESLASH
+                    );
+                }
+                fputcsv(
+                    $fp,
+                    $this->convertRow($row),
+                    $this->separator,
+                    self::DOUBLEQUOTE,
+                    self::DOUBLESLASH
+                );
+                $i++;
+            }
+
+            fclose($fp);
+        };
+
+        parent::__construct($callback);
+
+        $this->headers->set('Content-Type', 'text/csv');
+        $this->headers->set(
+            'Content-Disposition',
+            sprintf('attachment; filename="%s"', $this->fileName)
+        );
+    }
+}

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -256,4 +256,28 @@ class CSVResponseTest extends TestCase
             ['name' => 'Marcel', 'tags' => ['a', 'b']],
         ]);
     }
+
+    public function testCallableDataSource(): void
+    {
+        $callable = function () {
+            return [
+                ['firstName' => 'Marcel', 'lastName' => 'TOTO'],
+                ['firstName' => 'Maurice', 'lastName' => 'TATA'],
+            ];
+        };
+        $response = new CSVResponse($callable);
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $response->getContent()
+        );
+    }
+
+    public function testCallableReturningNonIterableThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The callable must return an iterable.');
+        new CSVResponse(function () {
+            return 'not iterable';
+        });
+    }
 }

--- a/tests/StreamedCSVResponseTest.php
+++ b/tests/StreamedCSVResponseTest.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Ilbee\CSVResponse\Tests;
+
+use Ilbee\CSVResponse\CSVResponseInterface;
+use Ilbee\CSVResponse\StreamedCSVResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ilbee\CSVResponse\StreamedCSVResponse
+ */
+class StreamedCSVResponseTest extends TestCase
+{
+    protected function getData(): array
+    {
+        return [
+            ['firstName' => 'Marcel', 'lastName' => 'TOTO'],
+            ['firstName' => 'Maurice', 'lastName' => 'TATA'],
+        ];
+    }
+
+    private function getStreamedContent(StreamedCSVResponse $response): string
+    {
+        ob_start();
+        $response->sendContent();
+        return ob_get_clean();
+    }
+
+    public function testResponse(): void
+    {
+        $response = new StreamedCSVResponse($this->getData());
+        $content = $this->getStreamedContent($response);
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $content
+        );
+    }
+
+    public function testCommaSeparator(): void
+    {
+        $response = new StreamedCSVResponse(
+            $this->getData(),
+            'export.csv',
+            CSVResponseInterface::COMMA
+        );
+        $content = $this->getStreamedContent($response);
+        $this->assertSame(
+            "firstName,lastName\nMarcel,TOTO\nMaurice,TATA\n",
+            $content
+        );
+    }
+
+    public function testHeaders(): void
+    {
+        $response = new StreamedCSVResponse($this->getData(), 'my-file.csv');
+        $this->assertEquals('text/csv', $response->headers->get('content-type'));
+        $this->assertEquals(
+            'attachment; filename="my-file.csv"',
+            $response->headers->get('content-disposition')
+        );
+    }
+
+    public function testDefaultFileName(): void
+    {
+        $response = new StreamedCSVResponse($this->getData());
+        $this->assertEquals(
+            'attachment; filename="CSVExport.csv"',
+            $response->headers->get('content-disposition')
+        );
+    }
+
+    public function testBomEnabled(): void
+    {
+        $response = new StreamedCSVResponse(
+            $this->getData(),
+            null,
+            CSVResponseInterface::SEMICOLON,
+            true
+        );
+        $content = $this->getStreamedContent($response);
+        $this->assertStringStartsWith("\xEF\xBB\xBF", $content);
+        $this->assertSame(
+            "\xEF\xBB\xBF" . "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $content
+        );
+    }
+
+    public function testBomDisabledByDefault(): void
+    {
+        $response = new StreamedCSVResponse($this->getData());
+        $content = $this->getStreamedContent($response);
+        $this->assertStringStartsNotWith("\xEF\xBB\xBF", $content);
+    }
+
+    public function testDateTime(): void
+    {
+        $now = new \DateTime();
+        $response = new StreamedCSVResponse([['datetime' => $now]]);
+        $content = $this->getStreamedContent($response);
+        $this->assertStringContainsString($now->format('Y-m-d H:i:s'), $content);
+    }
+
+    public function testCustomDateFormat(): void
+    {
+        $now = new \DateTime('2025-06-15 14:30:00');
+        $response = new StreamedCSVResponse(
+            [['datetime' => $now]],
+            null,
+            CSVResponseInterface::SEMICOLON,
+            false,
+            'd/m/Y'
+        );
+        $content = $this->getStreamedContent($response);
+        $this->assertSame("datetime\n15/06/2025\n", $content);
+    }
+
+    public function testNullValue(): void
+    {
+        $response = new StreamedCSVResponse([
+            ['name' => 'Marcel', 'email' => null],
+        ]);
+        $content = $this->getStreamedContent($response);
+        $this->assertSame("name;email\nMarcel;\n", $content);
+    }
+
+    public function testBooleanValues(): void
+    {
+        $response = new StreamedCSVResponse([
+            ['name' => 'Marcel', 'active' => true, 'deleted' => false],
+        ]);
+        $content = $this->getStreamedContent($response);
+        $this->assertSame(
+            "name;active;deleted\nMarcel;true;false\n",
+            $content
+        );
+    }
+
+    public function testHeadersDisabled(): void
+    {
+        $response = new StreamedCSVResponse(
+            $this->getData(),
+            null,
+            CSVResponseInterface::SEMICOLON,
+            false,
+            'Y-m-d H:i:s',
+            false
+        );
+        $content = $this->getStreamedContent($response);
+        $this->assertSame("Marcel;TOTO\nMaurice;TATA\n", $content);
+    }
+
+    public function testFormulaInjectionSanitized(): void
+    {
+        $data = [
+            ['name' => '=CMD|"/C calc"!A0', 'email' => 'test@test.com'],
+            ['name' => '+SUM(A1:A2)', 'email' => '-data'],
+            ['name' => '@import', 'email' => "\tmalicious"],
+        ];
+        $response = new StreamedCSVResponse($data);
+        $content = $this->getStreamedContent($response);
+
+        $this->assertStringContainsString("'=CMD", $content);
+        $this->assertStringContainsString("'+SUM", $content);
+        $this->assertStringContainsString("'-data", $content);
+        $this->assertStringContainsString("'@import", $content);
+    }
+
+    public function testFormulaInjectionSanitizationDisabled(): void
+    {
+        $data = [['name' => '=SUM(A1:A2)']];
+        $response = new StreamedCSVResponse(
+            $data,
+            null,
+            CSVResponseInterface::SEMICOLON,
+            false,
+            'Y-m-d H:i:s',
+            true,
+            false
+        );
+        $content = $this->getStreamedContent($response);
+        $this->assertStringContainsString('=SUM(A1:A2)', $content);
+        $this->assertStringNotContainsString("'=SUM", $content);
+    }
+
+    public function testNestedArrayThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Nested arrays are not supported');
+        $response = new StreamedCSVResponse([
+            ['name' => 'Marcel', 'tags' => ['a', 'b']],
+        ]);
+        ob_start();
+        try {
+            $response->sendContent();
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    public function testCallableDataSource(): void
+    {
+        $callable = function () {
+            return [
+                ['firstName' => 'Marcel', 'lastName' => 'TOTO'],
+                ['firstName' => 'Maurice', 'lastName' => 'TATA'],
+            ];
+        };
+        $response = new StreamedCSVResponse($callable);
+        $content = $this->getStreamedContent($response);
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $content
+        );
+    }
+
+    public function testCallableReturningGenerator(): void
+    {
+        $callable = function () {
+            yield ['firstName' => 'Marcel', 'lastName' => 'TOTO'];
+            yield ['firstName' => 'Maurice', 'lastName' => 'TATA'];
+        };
+        $response = new StreamedCSVResponse($callable);
+        $content = $this->getStreamedContent($response);
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $content
+        );
+    }
+
+    public function testCallableReturningNonIterableThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The callable must return an iterable.');
+        $response = new StreamedCSVResponse(function () {
+            return 'not iterable';
+        });
+        ob_start();
+        try {
+            $response->sendContent();
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    public function testGeneratorDataSource(): void
+    {
+        $generator = function () {
+            yield ['firstName' => 'Marcel', 'lastName' => 'TOTO'];
+            yield ['firstName' => 'Maurice', 'lastName' => 'TATA'];
+        };
+        $response = new StreamedCSVResponse($generator());
+        $content = $this->getStreamedContent($response);
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $content
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #12

- Add `StreamedCSVResponse` extending Symfony's `StreamedResponse` — writes CSV rows directly to `php://output` without buffering, enabling large dataset exports without hitting memory limits
- Extract shared logic into `CSVResponseInterface` (constants) and `CSVResponseTrait` (value conversion, formula sanitization, callable resolution)
- Refactor `CSVResponse` to use the new interface + trait — zero BC break
- Both classes now accept `callable` data sources for lazy initialization (e.g. a closure returning a generator from a DB query)

## Files

| File | Change |
|------|--------|
| `src/CSVResponseInterface.php` | New — shared constants |
| `src/CSVResponseTrait.php` | New — shared logic |
| `src/CSVResponse.php` | Refactored to use interface + trait |
| `src/StreamedCSVResponse.php` | New — streamed response class |
| `tests/StreamedCSVResponseTest.php` | New — 18 tests |
| `tests/CSVResponseTest.php` | 2 new callable tests |

## Test plan

- [x] 37 tests, 60 assertions — all pass
- [x] PHPStan level 5 — no errors
- [x] php-cs-fixer — no issues
- [x] PHP 7.4 compatibility verified (no union types, match, named args)
- [x] Existing CSVResponse tests unchanged and passing (no BC break)