### PR TITLE
Fix HTTP header injection and CSV injection in headers

### DIFF
--- a/src/CSVResponseTrait.php
+++ b/src/CSVResponseTrait.php
@@ -82,8 +82,25 @@ trait CSVResponseTrait
         $this->dateFormat = $dateFormat;
         $this->sanitizeFormulas = $sanitizeFormulas;
         if ($fileName) {
-            $this->fileName = $fileName;
+            $this->fileName = $this->sanitizeFileName($fileName);
         }
+    }
+
+    private function sanitizeFileName(string $fileName): string
+    {
+        $fileName = str_replace(
+            ["\r", "\n", "\t", '"', "\0"],
+            '',
+            $fileName
+        );
+
+        $fileName = basename($fileName);
+
+        if ($fileName === '' || $fileName === '.') {
+            return 'CSVExport.csv';
+        }
+
+        return $fileName;
     }
 
     /**
@@ -107,6 +124,14 @@ trait CSVResponseTrait
      */
     private function extractHeaders(array $row): array
     {
-        return array_keys($row);
+        $headers = array_keys($row);
+
+        if ($this->sanitizeFormulas) {
+            $headers = array_map(function ($header) {
+                return $this->sanitizeValue($header);
+            }, $headers);
+        }
+
+        return $headers;
     }
 }

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -280,4 +280,54 @@ class CSVResponseTest extends TestCase
             return 'not iterable';
         });
     }
+
+    public function testFileNameSanitizesHeaderInjection(): void
+    {
+        $response = new CSVResponse(
+            $this->getData(),
+            "evil.csv\"\r\nX-Injected: true"
+        );
+        $disposition = $response->headers->get('content-disposition');
+        $this->assertStringNotContainsString("\r", $disposition);
+        $this->assertStringNotContainsString("\n", $disposition);
+        $this->assertStringNotContainsString('"evil.csv"', $disposition);
+    }
+
+    public function testFileNameSanitizesPathTraversal(): void
+    {
+        $response = new CSVResponse(
+            $this->getData(),
+            '../../etc/passwd'
+        );
+        $this->assertEquals(
+            'attachment; filename="passwd"',
+            $response->headers->get('content-disposition')
+        );
+    }
+
+    public function testFileNameFallbackOnEmpty(): void
+    {
+        $response = new CSVResponse(
+            $this->getData(),
+            "\r\n"
+        );
+        $this->assertEquals(
+            'attachment; filename="CSVExport.csv"',
+            $response->headers->get('content-disposition')
+        );
+    }
+
+    public function testFormulaInjectionInHeaders(): void
+    {
+        $data = [
+            ['=CMD' => 'value1', '+SUM' => 'value2', '@import' => 'value3'],
+        ];
+
+        $response = new CSVResponse($data);
+        $content = $response->getContent();
+
+        $this->assertStringContainsString("'=CMD", $content);
+        $this->assertStringContainsString("'+SUM", $content);
+        $this->assertStringContainsString("'@import", $content);
+    }
 }


### PR DESCRIPTION
## Summary
- **HTTP Header Injection (HIGH)**: Sanitize `fileName` to strip `\r`, `\n`, `\t`, `"`, null bytes and apply `basename()` — prevents CRLF injection in `Content-Disposition` header
- **CSV Injection in headers (MEDIUM)**: Apply formula sanitization (`=`, `+`, `-`, `@`, `\t`, `\r`, `\n` prefixes) to column headers via `extractHeaders()`, not just cell values
- Add 4 new tests covering header injection, path traversal, empty filename fallback, and formula injection in headers

## Test plan
- [x] All 41 tests pass
- [x] PHP CS Fixer: 0 issues
- [x] PHPStan: no errors
- [ ] Review that `sanitizeFileName()` covers all relevant attack vectors
- [ ] Verify StreamedCSVResponse inherits the fixes via the shared trait