### PR TITLE
Add CHANGELOG and fix CI badge URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.7.1] - 2026-03-27
+
+### Security
+
+- Fix HTTP header injection via `Content-Disposition` filename (sanitize CRLF, quotes, null bytes, path traversal)
+- Fix CSV formula injection in column headers (apply sanitization to headers, not just cell values)
+
+### Added
+
+- 4 new tests for filename sanitization and header formula injection
+
+## [1.7.0] - 2026-03-27
+
+### Added
+
+- `StreamedCSVResponse` class extending `StreamedResponse` for large CSV exports with constant memory usage
+- `CSVResponseInterface` with shared constants (`COMMA`, `SEMICOLON`, `DOUBLEQUOTE`, `DOUBLESLASH`)
+- `CSVResponseTrait` to share CSV logic between `CSVResponse` and `StreamedCSVResponse`
+- Callable data source support (callable returning an iterable)
+
+### Changed
+
+- Refactored `CSVResponse` to use `CSVResponseInterface` and `CSVResponseTrait`
+
+## [1.6.1] - 2026-03-27
+
+### Security
+
+- CSV formula injection protection: values starting with `=`, `+`, `-`, `@`, tab, CR, LF are prefixed with a single quote
+
+### Added
+
+- Support for iterable data sources (generators, `ArrayIterator`, etc.)
+
+## [1.6.0] - 2026-03-27
+
+### Added
+
+- Option to disable header row generation (`$includeHeaders` parameter)
+- Configurable DateTime format (`$dateFormat` parameter, default `Y-m-d H:i:s`)
+
+## [1.5.0] - 2026-03-27
+
+### Added
+
+- Optional UTF-8 BOM prefix for Excel compatibility (`$addBom` parameter)
+
+## [1.4.0] - 2026-03-27
+
+### Added
+
+- Handle `null` values (converted to empty string), booleans (`true`/`false`), and nested arrays (throws `InvalidArgumentException`)
+- Fix `DateTimeImmutable` formatting (now handled via `DateTimeInterface`)
+- Modernized CI: php-cs-fixer, PHPStan, split jobs, PHP/Symfony matrix
+
+### Fixed
+
+- Reverted PHP 8.0+ syntax to maintain PHP 7.4 compatibility
+
+## [1.3.0] - 2025-03-10
+
+### Changed
+
+- Extended CI matrix for newer PHP versions
+- Made `fputcsv` escape parameter explicit
+
+## [1.2.0] - 2024-02-05
+
+### Changed
+
+- Updated Symfony and PHP version constraints in `composer.json`
+
+## [1.1.1] - 2023-03-12
+
+### Changed
+
+- Broadened `symfony/http-foundation` version constraint
+
+## [1.1.0] - 2023-03-11
+
+### Added
+
+- PHPUnit test suite with PHP version matrix
+- GitHub Actions CI workflow
+
+## [1.0.4] - 2021-03-26
+
+### Changed
+
+- README updates
+
+[1.7.1]: https://github.com/ilbee/csv-response/compare/1.7.0...1.7.1
+[1.7.0]: https://github.com/ilbee/csv-response/compare/1.6.1...1.7.0
+[1.6.1]: https://github.com/ilbee/csv-response/compare/1.6.0...1.6.1
+[1.6.0]: https://github.com/ilbee/csv-response/compare/1.5.0...1.6.0
+[1.5.0]: https://github.com/ilbee/csv-response/compare/1.4.0...1.5.0
+[1.4.0]: https://github.com/ilbee/csv-response/compare/1.3.0...1.4.0
+[1.3.0]: https://github.com/ilbee/csv-response/compare/1.2.0...1.3.0
+[1.2.0]: https://github.com/ilbee/csv-response/compare/1.1.1...1.2.0
+[1.1.1]: https://github.com/ilbee/csv-response/compare/1.1.0...1.1.1
+[1.1.0]: https://github.com/ilbee/csv-response/compare/1.0.4...1.1.0
+[1.0.4]: https://github.com/ilbee/csv-response/releases/tag/1.0.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSV Response
 
-[![CI](https://github.com/ilbee/csv-response/actions/workflows/php.yml/badge.svg)](https://github.com/ilbee/csv-response/actions/workflows/php.yml)
+[![CI](https://github.com/ilbee/csv-response/actions/workflows/ci.yml/badge.svg)](https://github.com/ilbee/csv-response/actions/workflows/ci.yml)
 [![PHP](https://img.shields.io/badge/PHP-7.4%2B-8892BF)](https://www.php.net/)
 [![Symfony](https://img.shields.io/badge/Symfony-4.4%20%7C%205.x%20%7C%206.x%20%7C%207.x-black)](https://symfony.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE)


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` covering all releases from 1.0.4 to 1.7.1 (Keep a Changelog format)
- Fix CI badge in README: `php.yml` → `ci.yml` (the actual workflow filename)

## Test plan
- [ ] Verify CI badge renders correctly on the repo page
- [ ] Review CHANGELOG entries against git history