### PR TITLE
Fix HTTP header injection via HeaderUtils::makeDisposition()

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -2,6 +2,7 @@
 
 namespace Ilbee\CSVResponse;
 
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\Response;
 
 class CSVResponse extends Response implements CSVResponseInterface
@@ -32,7 +33,10 @@ class CSVResponse extends Response implements CSVResponseInterface
         $this->headers->set('Content-Type', 'text/csv');
         $this->headers->set(
             'Content-Disposition',
-            sprintf('attachment; filename="%s"', $this->fileName)
+            HeaderUtils::makeDisposition(
+                HeaderUtils::DISPOSITION_ATTACHMENT,
+                $this->fileName
+            )
         );
     }
 

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -43,7 +43,7 @@ class CSVResponseTest extends TestCase
             $response->headers->get('content-type')
         );
         $this->assertEquals(
-            'attachment; filename="my-file-name.csv"',
+            'attachment; filename=my-file-name.csv',
             $response->headers->get('content-disposition')
         );
     }
@@ -300,7 +300,7 @@ class CSVResponseTest extends TestCase
             '../../etc/passwd'
         );
         $this->assertEquals(
-            'attachment; filename="passwd"',
+            'attachment; filename=passwd',
             $response->headers->get('content-disposition')
         );
     }
@@ -312,7 +312,7 @@ class CSVResponseTest extends TestCase
             "\r\n"
         );
         $this->assertEquals(
-            'attachment; filename="CSVExport.csv"',
+            'attachment; filename=CSVExport.csv',
             $response->headers->get('content-disposition')
         );
     }


### PR DESCRIPTION
## Summary
- Replace manual `sprintf('attachment; filename="%s"', ...)` with Symfony's `HeaderUtils::makeDisposition()` for proper RFC 6266 header escaping
- Prevents HTTP header injection via crafted filenames containing `"` or CRLF characters
- Updates test assertions to match `HeaderUtils` output format (unquoted simple filenames per RFC)

Closes #24

## Test plan
- [x] All 41 tests pass
- [x] PHPStan clean
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)