### PR TITLE
Throw InvalidArgumentException for objects without __toString()

### DIFF
--- a/src/CSVResponseTrait.php
+++ b/src/CSVResponseTrait.php
@@ -54,6 +54,14 @@ trait CSVResponseTrait
             throw new \InvalidArgumentException(
                 sprintf('Nested arrays are not supported in CSV data (column "%s").', $key)
             );
+        } elseif (is_object($value) && !method_exists($value, '__toString')) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Object of class "%s" cannot be converted to string (column "%s").',
+                    get_class($value),
+                    $key
+                )
+            );
         }
 
         return $value;

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -317,6 +317,31 @@ class CSVResponseTest extends TestCase
         );
     }
 
+    public function testObjectWithToStringIsConverted(): void
+    {
+        $obj = new class {
+            public function __toString(): string
+            {
+                return 'string-value';
+            }
+        };
+
+        $response = new CSVResponse([
+            ['name' => 'Marcel', 'value' => $obj],
+        ]);
+        $this->assertStringContainsString('string-value', $response->getContent());
+    }
+
+    public function testObjectWithoutToStringThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot be converted to string');
+
+        new CSVResponse([
+            ['name' => 'Marcel', 'value' => new \stdClass()],
+        ]);
+    }
+
     public function testFormulaInjectionInHeaders(): void
     {
         $data = [


### PR DESCRIPTION
## Summary
- Reject objects that don't implement `__toString()` in CSV data values with a clear `InvalidArgumentException` instead of letting PHP error out on `fputcsv`
- Objects with `__toString()` continue to work as before

Closes #27

## Test plan
- [x] `testObjectWithoutToStringThrowsException` — `stdClass` throws with message "cannot be converted to string"
- [x] `testObjectWithToStringIsConverted` — anonymous class with `__toString()` outputs correctly
- [x] All 43 tests pass, PHPStan clean, CS clean