### PR TITLE
Add optional maxRows parameter to limit data size

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -19,13 +19,14 @@ class CSVResponse extends Response implements CSVResponseInterface
         bool $addBom = false,
         string $dateFormat = 'Y-m-d H:i:s',
         bool $includeHeaders = true,
-        bool $sanitizeFormulas = true
+        bool $sanitizeFormulas = true,
+        ?int $maxRows = null
     ) {
         parent::__construct();
 
         $this->initCSVProperties($fileName, $separator, $dateFormat, $sanitizeFormulas);
 
-        $content = $this->initContent($this->resolveData($data), $includeHeaders);
+        $content = $this->initContent($this->resolveData($data), $includeHeaders, $maxRows);
         if ($addBom) {
             $content = "\xEF\xBB\xBF" . $content;
         }
@@ -40,11 +41,19 @@ class CSVResponse extends Response implements CSVResponseInterface
         );
     }
 
-    private function initContent(iterable $data, bool $includeHeaders = true): string
-    {
+    private function initContent(
+        iterable $data,
+        bool $includeHeaders = true,
+        ?int $maxRows = null
+    ): string {
         $fp = fopen('php://temp', 'w');
         $i = 0;
         foreach ($data as $row) {
+            if ($maxRows !== null && $i >= $maxRows) {
+                throw new \OverflowException(
+                    sprintf('Data exceeds the maximum allowed number of rows (%d).', $maxRows)
+                );
+            }
             if ($i === 0 && $includeHeaders) {
                 fputcsv(
                     $fp,

--- a/tests/CSVResponseTest.php
+++ b/tests/CSVResponseTest.php
@@ -355,4 +355,48 @@ class CSVResponseTest extends TestCase
         $this->assertStringContainsString("'+SUM", $content);
         $this->assertStringContainsString("'@import", $content);
     }
+
+    public function testMaxRowsAllowsDataWithinLimit(): void
+    {
+        $response = new CSVResponse(
+            $this->getData(),
+            null,
+            CSVResponse::SEMICOLON,
+            false,
+            'Y-m-d H:i:s',
+            true,
+            true,
+            10
+        );
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $response->getContent()
+        );
+    }
+
+    public function testMaxRowsThrowsWhenExceeded(): void
+    {
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('maximum allowed number of rows (1)');
+
+        new CSVResponse(
+            $this->getData(),
+            null,
+            CSVResponse::SEMICOLON,
+            false,
+            'Y-m-d H:i:s',
+            true,
+            true,
+            1
+        );
+    }
+
+    public function testMaxRowsNullMeansNoLimit(): void
+    {
+        $response = new CSVResponse($this->getData());
+        $this->assertSame(
+            "firstName;lastName\nMarcel;TOTO\nMaurice;TATA\n",
+            $response->getContent()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add optional `maxRows` constructor parameter (default `null` = no limit) to prevent unbounded memory usage
- Throws `OverflowException` when row count exceeds the limit
- Fully backward-compatible — existing code is unaffected

Closes #26

## Test plan
- [x] `testMaxRowsAllowsDataWithinLimit` — data within limit works normally
- [x] `testMaxRowsThrowsWhenExceeded` — exceeding limit throws `OverflowException`
- [x] `testMaxRowsNullMeansNoLimit` — default behavior unchanged
- [x] All 46 tests pass, PHPStan clean, CS clean